### PR TITLE
add rpsec test for validation the installation date

### DIFF
--- a/spec/models/stations_spec.rb
+++ b/spec/models/stations_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe Station do
 
       expect(station).to_not be_valid
     end
+
+    it "is invalid without an installation date" do
+      station = Station.new(name: "Station_1", city: "bike town", dock_count: 20)
+
+      expect(station).to_not be_valid
+    end
   end
 
   describe "Class Methods" do


### PR DESCRIPTION
I added a piece to the stations_spec.rb so that it can test to see if the model is invalid without the installation date. 